### PR TITLE
ci: simplify xref validation

### DIFF
--- a/.github/workflows/build-pr-preview.yml
+++ b/.github/workflows/build-pr-preview.yml
@@ -14,11 +14,8 @@ jobs:
       COMPONENT_BRANCH_NAME: ${{ github.head_ref }}
     steps:
       - name: Validate xref
-        # Branch of https://github.com/bonitasoft/bonita-documentation-site/pull/582
-        uses: bonitasoft/bonita-documentation-site/.github/actions/build-pr-site/@feat/xref_validation
+        uses: bonitasoft/bonita-documentation-site/.github/actions/build-pr-site/@master
         with:
-          # Branch of https://github.com/bonitasoft/bonita-documentation-site/pull/582
-          doc-site-branch: feat/xref_validation
           # '>' Replace newlines with spaces (folded)
           # '-' No newline at end (strip)
           build-preview-command: >-

--- a/.github/workflows/build-pr-preview.yml
+++ b/.github/workflows/build-pr-preview.yml
@@ -12,14 +12,6 @@ jobs:
     env:
       COMPONENT_NAME: central
       COMPONENT_BRANCH_NAME: ${{ github.head_ref }}
-      # Required to pass xref validation
-      CLOUD_BRANCH: 'master'
-      BCD_BRANCH: '4.0'
-      BONITA_BRANCH: '2023.1'
-      BONITA_BRANCH_FOR_CLOUD: '2022.1'
-      TOOLKIT_BRANCH: '1.0'
-      BONITA_BRANCH_2021_1: '2021.1'
-      BONITA_BRANCH_FOR_TOOLKIT: '2022.2'
     steps:
       - name: Validate xref
         # Branch of https://github.com/bonitasoft/bonita-documentation-site/pull/582
@@ -30,10 +22,6 @@ jobs:
           # '>' Replace newlines with spaces (folded)
           # '-' No newline at end (strip)
           build-preview-command: >-
-            ./build-preview.bash --use-multi-repositories
-            --start-page "${{ env.COMPONENT_NAME }}"::index.adoc
-            --component-with-branches "${{ env.COMPONENT_NAME }}":"${{ env.COMPONENT_BRANCH_NAME }}"
-            --component-with-branches bcd:"${{ env.BCD_BRANCH }},3.6"
-            --component-with-branches cloud:"${{ env.CLOUD_BRANCH }}"
-            --component-with-branches bonita:"${{ env.BONITA_BRANCH }},${{ env.BONITA_BRANCH_2021_1 }},${{ env.BONITA_BRANCH_FOR_TOOLKIT }},${{ env.BONITA_BRANCH_FOR_CLOUD }}"
-            --component-with-branches test-toolkit:"${{ env.TOOLKIT_BRANCH }}" 
+            ./build-preview.bash
+            --component "${{ env.COMPONENT_NAME }}"
+            --branch "${{ env.COMPONENT_BRANCH_NAME }}"

--- a/.github/workflows/build-pr-preview.yml
+++ b/.github/workflows/build-pr-preview.yml
@@ -7,7 +7,7 @@ on:
       - 'antora.yml'
       - '.github/workflows/build-pr-preview.yml'
 jobs:
-  build_preview:
+  validate_xref:
     runs-on: ubuntu-22.04
     env:
       COMPONENT_NAME: central
@@ -21,9 +21,12 @@ jobs:
       BONITA_BRANCH_2021_1: '2021.1'
       BONITA_BRANCH_FOR_TOOLKIT: '2022.2'
     steps:
-      - name: Build preview
-        uses: bonitasoft/bonita-documentation-site/.github/actions/build-pr-site/@master
+      - name: Validate xref
+        # Branch of https://github.com/bonitasoft/bonita-documentation-site/pull/582
+        uses: bonitasoft/bonita-documentation-site/.github/actions/build-pr-site/@feat/xref_validation
         with:
+          # Branch of https://github.com/bonitasoft/bonita-documentation-site/pull/582
+          doc-site-branch: feat/xref_validation
           # '>' Replace newlines with spaces (folded)
           # '-' No newline at end (strip)
           build-preview-command: >-

--- a/modules/ROOT/pages/overview.adoc
+++ b/modules/ROOT/pages/overview.adoc
@@ -1,13 +1,6 @@
 = Bonita Central
 :description: Bonita Central.
 
-[CAUTION]
-====
-* internal link xref:::i-do-not-exist.adoc[do not exist internal]
-* bonita link xref:{bonitaVersion}@bonita::performance-tuning_NOT_EXIST.adoc[do not exist bonita]
-====
-
-
 Welcome to Bonita Central, the production management tool that: 
 
 - “has all in one place” for configuration 

--- a/modules/ROOT/pages/overview.adoc
+++ b/modules/ROOT/pages/overview.adoc
@@ -1,6 +1,13 @@
 = Bonita Central
 :description: Bonita Central.
 
+[CAUTION]
+====
+* internal link xref:::i-do-not-exist.adoc[do not exist internal]
+* bonita link xref:{bonitaVersion}@bonita::performance-tuning_NOT_EXIST.adoc[do not exist bonita]
+====
+
+
 Welcome to Bonita Central, the production management tool that: 
 
 - “has all in one place” for configuration 


### PR DESCRIPTION
Use the new Antora Atlas feature. There is no more need to reference all dependent components/versions to validate xrefs.


### Tests done with this PR

- [x] No impact of the new doc-site implementation when using the "multi-repositories" option (existing configuration)
  - [x] pass when there is no xref error 97ff973 
  - [x] still detect xref error a261394
- [x] xref validation is still working when building only a single version of the component 6042cbf