### PR TITLE
ci: fail validation on asciidoctor warnings

### DIFF
--- a/.github/workflows/build-pr-preview.yml
+++ b/.github/workflows/build-pr-preview.yml
@@ -22,3 +22,4 @@ jobs:
             ./build-preview.bash
             --component "${{ env.COMPONENT_NAME }}"
             --branch "${{ env.COMPONENT_BRANCH_NAME }}"
+          fail-on-warning: true

--- a/.github/workflows/contribution-checks.yml
+++ b/.github/workflows/contribution-checks.yml
@@ -2,7 +2,7 @@ name: Contribution checks
 
 on:
   pull_request:
-    types: [opened, edited, synchronize]
+    types: [opened, reopened, synchronize]
 
 jobs:
   pr-content-check:
@@ -12,5 +12,5 @@ jobs:
         uses: bonitasoft/actions/packages/pr-diff-checker@v2
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
-          diffDoesNotContain: '["https://documentation.bonitasoft.com/", "Bonita BPM"]'
+          diffDoesNotContain: '["https://documentation.bonitasoft.com/", "Bonita BPM", "link:https", "link:http", "xref:https", "xref:http", "xref:_", "xref:#"]'
           extensionsToCheck: '[".adoc"]'


### PR DESCRIPTION
The workflow that checks changes now prohibits certain erroneous forms of xref and link, to prevent new errors from being added.