### PR TITLE
ci: use a new action to better check the contribution content

### DIFF
--- a/.github/workflows/contribution-checks.yml
+++ b/.github/workflows/contribution-checks.yml
@@ -2,15 +2,9 @@ name: Contribution checks
 
 on:
   pull_request:
-    types: [opened, reopened, synchronize]
 
 jobs:
-  pr-content-check:
-    runs-on: ubuntu-22.04
-    steps:
-      - name: Check PR content
-        uses: bonitasoft/actions/packages/pr-diff-checker@v2
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          diffDoesNotContain: '["https://documentation.bonitasoft.com/", "Bonita BPM", "link:https", "link:http", "xref:https", "xref:http", "xref:_", "xref:#"]'
-          extensionsToCheck: '[".adoc"]'
+  check_antora_content_guidelines:
+    permissions:
+      pull-requests: write # "pr-antora-content-guidelines-checker" write PR comments when the PR doesn't match the "Guidelines"
+    uses: bonitasoft/bonita-documentation-site/.github/workflows/_reusable_pr-antora-content-guidelines-checker.yml@master


### PR DESCRIPTION
Use new action to validate if contribution (PR) follows the guidelines on documentation content

For now only check if:
* files contain :description: attributes
* files not contain any forbidden attributes

Covers bonitasoft/bonita-documentation-site#591
Covers bonitasoft/bonita-documentation-site#422